### PR TITLE
Optimizing the one character auto-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## 0.1.0 - First Release
-* Implement main features
-* Create main dictionaries
+## Patch notes :
+
+## 0.2.2
+* Optimize one character completion
+
+## 0.2.1
+* Update dictionaries
 
 ## 0.2.0
 * Add location dictionaries
@@ -8,5 +12,6 @@
 * Add unique fussy search
 * Improve sorting
 
-## 0.2.1
-* Update dictionaries
+## 0.1.0 - First Release
+* Implement main features
+* Create main dictionaries

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,21 +2,20 @@ MIT License
 
 Copyright (c) 2019 FUN
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -77,7 +77,7 @@ module.exports =
     needle  = prefix.toLowerCase().replace('_', '').replace(' ', '')
 
     # Optimize request for unique Char string prefix
-    if needle.length = 1
+    if needle.length == 1
       # Only search from 1st Char
       regex = new RegExp('^' + needle)
     else

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -75,7 +75,13 @@ module.exports =
 
     bracket = atom.config.get('autocomplete-eu4.bracket')
     needle  = prefix.toLowerCase().replace('_', '').replace(' ', '')
-    regex   = new RegExp(needle)
+
+    # Optimize request for unique Char string prefix
+    if needle.length = 1
+      # Only search from 1st Char
+      regex = new RegExp('^' + needle)
+    else
+      regex = new RegExp(needle)
 
     for index, entry of dictionary
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "autocomplete-eu4",
   "main": "./lib/main",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Autocomplete Plus provider for Europa Universalis IV",
   "keywords": [
     "Autocomplete",


### PR DESCRIPTION
Adding a test on the `prefix string length` to catch unique character auto-completion.
And only searching for this prefix the 1st character matching from dictionaries with regex : `^(.*)`

That is **improving the responsiveness** of the auto-completion greatly in my opinion and **doesn't decrease the quality of the request** as one character request doesn't make sense to match inside the entire string but is only relevant for the 1st char of the string.